### PR TITLE
Add video element support

### DIFF
--- a/src/document.js
+++ b/src/document.js
@@ -1,6 +1,7 @@
 import {Canvas} from './canvas'
 import Image from './Image'
 import {Element} from './element'
+import Video from './video';
 
 const stack = {}
 
@@ -36,6 +37,10 @@ export default {
       case 'image':
       case 'img': {
         return new Image()
+      }
+
+      case 'video': {
+        return new Video();
       }
 
       default: {

--- a/src/video.js
+++ b/src/video.js
@@ -1,0 +1,8 @@
+export default function() {
+    const video = wx.createVideo({width: 0, height: 0, controls: false})
+    video.canPlayType = () => {
+        return true;
+    }
+    return video
+  }
+  


### PR DESCRIPTION
Adds a "hacky" support for the video element so that the adapter works with the Pixi Shader Toy Filter Render Texture demo for instance (https://pixijs.com/7.x/examples/filters-advanced/shader-toy-filter-render-texture).